### PR TITLE
Mesoscale momentum parameterization with ANN

### DIFF
--- a/src/parameterizations/lateral/MOM_ANN.F90
+++ b/src/parameterizations/lateral/MOM_ANN.F90
@@ -17,23 +17,23 @@ public ANN_init, ANN_apply, ANN_end
 !! i.e. stores the matrix A and bias b
 !! for matrix-vector multiplication
 !! y = A*x + b.
-type, private :: layer_type; private 
+type, private :: layer_type; private
   integer :: output_width        !< Number of rows in matrix A
   integer :: input_width         !< Number of columns in matrix A
   logical :: activation = .True. !< If true, apply the default activation function
 
-  real, allocatable :: A(:,:) !< Matrix in column-major order 
-                              !! of size A(output_width, input_width)
-  real, allocatable :: b(:)   !< bias vector of size output_width
+  real, allocatable :: A(:,:) !< Matrix in column-major order
+                              !! of size A(output_width, input_width) [nondim]
+  real, allocatable :: b(:)   !< bias vector of size output_width [nondim]
 end type layer_type
 
 !> Control structure/type for ANN
-type, public :: ANN_CS ; private 
+type, public :: ANN_CS ; private
   ! Parameters
   integer :: num_layers          !< Number of layers in the ANN, including the input and output.
                                  !! For example, for ANN with one hidden layer, num_layers = 3.
   integer, allocatable &
-          :: layer_sizes(:)      !< Array of length num_layers, storing the number of neurons in 
+          :: layer_sizes(:)      !< Array of length num_layers, storing the number of neurons in
                                  !! each layer.
 
   type(layer_type), allocatable &
@@ -42,16 +42,16 @@ type, public :: ANN_CS ; private
 
   real, allocatable :: &
     input_norms(:), & !< Array of length layer_sizes(1). By these values
-                      !! each input feature will be divided before feeding into the ANN
+                      !! each input feature will be divided before feeding into the ANN [arbitrary]
     output_norms(:)   !< Array of length layer_sizes(num_layers). By these values
-                      !! each output of the ANN will be multiplied
+                      !! each output of the ANN will be multiplied [arbitrary]
 end type ANN_CS
 
 contains
 
 !> Initialization of ANN. Allocates memory and reads ANN parameters from NetCDF file.
 !! The NetCDF file must contain:
-!! Integer num_layers. 
+!! Integer num_layers.
 !! Integer arrays: layer_sizes, input_norms, output_norms
 !! Matrices and biases for Linear layers can be Real(4) or Real(8) and
 !! are named as: A0, b0 for the first layer; A1, b1 for the second layer and so on.
@@ -67,21 +67,21 @@ subroutine ANN_init(CS, NNfile)
 
   ! Read the number of layers
   call MOM_read_data(NNfile, "num_layers", CS%num_layers)
-  
+
   ! Read size of layers
   allocate(CS%layer_sizes(CS%num_layers))
   call MOM_read_data(NNfile, "layer_sizes", CS%layer_sizes)
-  
+
   ! Read normalization factors
   allocate(CS%input_norms(CS%layer_sizes(1)))
   allocate(CS%output_norms(CS%layer_sizes(CS%num_layers)))
 
   call MOM_read_data(NNfile, 'input_norms', CS%input_norms)
   call MOM_read_data(NNfile, 'output_norms', CS%output_norms)
-  
+
   ! Allocate the Linear transformations between layers.
   allocate(CS%layers(CS%num_layers-1))
-  
+
   ! Allocate and read matrix A and bias b for each layer
   do i = 1,CS%num_layers-1
     CS%layers(i)%input_width = CS%layer_sizes(i)
@@ -99,7 +99,7 @@ subroutine ANN_init(CS, NNfile)
     fieldname = trim('b') // trim(layer_num_str)
     call MOM_read_data(NNfile, fieldname, CS%layers(i)%b)
   enddo
-  
+
   ! No activation function for the last layer
   CS%layers(CS%num_layers-1)%activation = .False.
 
@@ -114,8 +114,8 @@ subroutine ANN_test(CS, NNfile)
   type(ANN_CS), intent(inout)  :: CS     !< ANN control structure.
   character(*), intent(in)     :: NNfile !< The name of NetCDF file having neural network parameters
 
-  real, dimension(:), allocatable :: x_test, y_test, y_pred
-  real :: relative_error
+  real, dimension(:), allocatable :: x_test, y_test, y_pred ! [arbitrary]
+  real :: relative_error ! [arbitrary]
   character(len=200) :: relative_error_str
 
   ! Allocate data
@@ -129,7 +129,7 @@ subroutine ANN_test(CS, NNfile)
 
   ! Compute prediction
   call ANN_apply(x_test, y_pred, CS)
-  
+
   relative_error = maxval(abs(y_pred - y_test)) / maxval(abs(y_test))
 
   if (relative_error > 1e-5) then
@@ -160,17 +160,17 @@ subroutine ANN_end(CS)
 
 end subroutine ANN_end
 
-!> Main ANN function: normalizes input vector x, applies Linear layers, and 
+!> Main ANN function: normalizes input vector x, applies Linear layers, and
 !! un-normalizes the output.
 subroutine ANN_apply(x, y, CS)
   type(ANN_CS), intent(in) :: CS !< ANN control structure
 
   real, dimension(CS%layer_sizes(1)), &
-                  intent(in)  :: x !< input 
+                  intent(in)  :: x !< input [arbitrary]
   real, dimension(CS%layer_sizes(CS%num_layers)), &
-                  intent(out) :: y !< output 
-  
-  real, allocatable :: x_1(:), x_2(:) ! intermediate states. 
+                  intent(out) :: y !< output [arbitrary]
+
+  real, allocatable :: x_1(:), x_2(:) ! intermediate states [nondim]
   integer :: i
 
   ! Normalize input
@@ -178,9 +178,9 @@ subroutine ANN_apply(x, y, CS)
   do i = 1,CS%layer_sizes(1)
       x_1(i) = x(i) / CS%input_norms(i)
   enddo
-  
+
   ! Apply Linear layers
-  do i = 1, CS%num_layers-1 
+  do i = 1, CS%num_layers-1
     allocate(x_2(CS%layer_sizes(i+1)))
     call Layer_apply(x_1, x_2, CS%layers(i))
     deallocate(x_1)
@@ -188,7 +188,7 @@ subroutine ANN_apply(x, y, CS)
     x_1 = x_2
     deallocate(x_2)
   enddo
-  
+
   ! Un-normalize output
   do i = 1, CS%layer_sizes(CS%num_layers)
     y(i) = x_1(i) * CS%output_norms(i)
@@ -199,21 +199,21 @@ end subroutine ANN_apply
 
 !> The default activation function
 pure function activation_fn(x) result (y)
-  real, intent(in)  :: x !< Scalar input value
-  real :: y !< Scalar output value
+  real, intent(in)  :: x !< Scalar input value [nondim]
+  real :: y !< Scalar output value [nondim]
 
   y = max(x, 0.0) ! ReLU activation
-  
+
 end function activation_fn
 
-!> Applies linear layer to input data x and stores the result in y with 
+!> Applies linear layer to input data x and stores the result in y with
 !! y = A*x + b with optional application of the activation function.
 subroutine Layer_apply(x, y, layer)
   type(layer_type), intent(in)  :: layer !< Linear layer
   real, dimension(layer%input_width), &
-                    intent(in)  :: x     !< Input vector
+                    intent(in)  :: x     !< Input vector [nondim]
   real, dimension(layer%output_width), &
-                    intent(out) :: y     !< Output vector
+                    intent(out) :: y     !< Output vector [nondim]
 
   integer :: i, j
 

--- a/src/parameterizations/lateral/MOM_ANN.F90
+++ b/src/parameterizations/lateral/MOM_ANN.F90
@@ -217,12 +217,15 @@ subroutine Layer_apply(x, y, layer)
 
   integer :: i, j
 
-  do j=1,layer%output_width
-    y(j) = 0.
-    do i=1,layer%input_width
+  y(:) = 0.
+  do i=1,layer%input_width
+    do j=1,layer%output_width
       ! Multiply by kernel
       y(j) = y(j) + ( x(i) * layer%A(j, i) )
     enddo
+  enddo
+
+  do j=1,layer%output_width
     ! Add bias
     y(j) = y(j) + layer%b(j)
     ! Apply activation function

--- a/src/parameterizations/lateral/MOM_ANN.F90
+++ b/src/parameterizations/lateral/MOM_ANN.F90
@@ -1,0 +1,235 @@
+!> Implements the general purpose ANN.
+module MOM_ANN
+
+! This file is part of MOM6. See LICENSE.md for the license
+
+use MOM_diag_mediator, only : diag_ctrl, time_type
+use MOM_io, only : MOM_read_data
+use MOM_error_handler, only : MOM_error, FATAL, MOM_mesg
+!
+implicit none ; private
+
+#include <MOM_memory.h>
+
+public ANN_init, ANN_apply, ANN_end
+
+!> Type for a single Linear layer of ANN,
+!! i.e. stores the matrix A and bias b
+!! for matrix-vector multiplication
+!! y = A*x + b.
+type, private :: layer_type; private 
+  integer :: output_width        !< Number of rows in matrix A
+  integer :: input_width         !< Number of columns in matrix A
+  logical :: activation = .True. !< If true, apply the default activation function
+
+  real, allocatable :: A(:,:) !< Matrix in column-major order 
+                              !! of size A(output_width, input_width)
+  real, allocatable :: b(:)   !< bias vector of size output_width
+end type layer_type
+
+!> Control structure/type for ANN
+type, public :: ANN_CS ; private 
+  ! Parameters
+  integer :: num_layers          !< Number of layers in the ANN, including the input and output.
+                                 !! For example, for ANN with one hidden layer, num_layers = 3.
+  integer, allocatable &
+          :: layer_sizes(:)      !< Array of length num_layers, storing the number of neurons in 
+                                 !! each layer.
+
+  type(layer_type), allocatable &
+          :: layers(:)           !< Array of length num_layers-1, where each element is the Linear
+                                 !! transformation between layers defined by Matrix A and vias b.
+
+  real, allocatable :: &
+    input_norms(:), & !< Array of length layer_sizes(1). By these values
+                      !! each input feature will be divided before feeding into the ANN
+    output_norms(:)   !< Array of length layer_sizes(num_layers). By these values
+                      !! each output of the ANN will be multiplied
+end type ANN_CS
+
+contains
+
+!> Initialization of ANN. Allocates memory and reads ANN parameters from NetCDF file.
+!! The NetCDF file must contain:
+!! Integer num_layers. 
+!! Integer arrays: layer_sizes, input_norms, output_norms
+!! Matrices and biases for Linear layers can be Real(4) or Real(8) and
+!! are named as: A0, b0 for the first layer; A1, b1 for the second layer and so on.
+subroutine ANN_init(CS, NNfile)
+  type(ANN_CS), intent(inout)  :: CS     !< ANN control structure.
+  character(*), intent(in)     :: NNfile !< The name of NetCDF file having neural network parameters
+
+  integer :: i
+  character(len=1) :: layer_num_str
+  character(len=3) :: fieldname
+
+  call MOM_mesg('ANN: init from ' // trim(NNfile), 2)
+
+  ! Read the number of layers
+  call MOM_read_data(NNfile, "num_layers", CS%num_layers)
+  
+  ! Read size of layers
+  allocate(CS%layer_sizes(CS%num_layers))
+  call MOM_read_data(NNfile, "layer_sizes", CS%layer_sizes)
+  
+  ! Read normalization factors
+  allocate(CS%input_norms(CS%layer_sizes(1)))
+  allocate(CS%output_norms(CS%layer_sizes(CS%num_layers)))
+
+  call MOM_read_data(NNfile, 'input_norms', CS%input_norms)
+  call MOM_read_data(NNfile, 'output_norms', CS%output_norms)
+  
+  ! Allocate the Linear transformations between layers.
+  allocate(CS%layers(CS%num_layers-1))
+  
+  ! Allocate and read matrix A and bias b for each layer
+  do i = 1,CS%num_layers-1
+    CS%layers(i)%input_width = CS%layer_sizes(i)
+    CS%layers(i)%output_width = CS%layer_sizes(i+1)
+
+    allocate(CS%layers(i)%A(CS%layers(i)%output_width, CS%layers(i)%input_width), source=0.)
+    ! Reading matrix A
+    write(layer_num_str, '(I0)') i-1
+    fieldname = trim('A') // trim(layer_num_str)
+    call MOM_read_data(NNfile, fieldname, CS%layers(i)%A, &
+                        (/1,1,1,1/),(/CS%layers(i)%output_width,CS%layers(i)%input_width,1,1/))
+
+    allocate(CS%layers(i)%b(CS%layers(i)%output_width), source=0.)
+    ! Reading bias b
+    fieldname = trim('b') // trim(layer_num_str)
+    call MOM_read_data(NNfile, fieldname, CS%layers(i)%b)
+  enddo
+  
+  ! No activation function for the last layer
+  CS%layers(CS%num_layers-1)%activation = .False.
+
+  call ANN_test(CS, NNfile)
+
+  call MOM_mesg('ANN: have been read from ' // trim(NNfile), 2)
+
+end subroutine ANN_init
+
+!> Test ANN by comparing the prediction with the test data.
+subroutine ANN_test(CS, NNfile)
+  type(ANN_CS), intent(inout)  :: CS     !< ANN control structure.
+  character(*), intent(in)     :: NNfile !< The name of NetCDF file having neural network parameters
+
+  real, dimension(:), allocatable :: x_test, y_test, y_pred
+  real :: relative_error
+  character(len=200) :: relative_error_str
+
+  ! Allocate data
+  allocate(x_test(CS%layer_sizes(1)))
+  allocate(y_test(CS%layer_sizes(CS%num_layers)))
+  allocate(y_pred(CS%layer_sizes(CS%num_layers)))
+
+  ! Read test vectors
+  call MOM_read_data(NNfile, 'x_test', x_test)
+  call MOM_read_data(NNfile, 'y_test', y_test)
+
+  ! Compute prediction
+  call ANN_apply(x_test, y_pred, CS)
+  
+  relative_error = maxval(abs(y_pred - y_test)) / maxval(abs(y_test))
+
+  if (relative_error > 1e-5) then
+    write(relative_error_str, '(ES12.4)') relative_error
+    call MOM_error(FATAL, 'Relative error in ANN prediction is too large: ' // trim(relative_error_str))
+  endif
+
+  deallocate(x_test)
+  deallocate(y_test)
+  deallocate(y_pred)
+end subroutine ANN_test
+
+!> Deallocates memory of ANN
+subroutine ANN_end(CS)
+  type(ANN_CS), intent(inout) :: CS !< ANN control structure.
+
+  integer :: i
+
+  deallocate(CS%layer_sizes)
+  deallocate(CS%input_norms)
+  deallocate(CS%output_norms)
+
+  do i = 1, CS%num_layers-1
+    deallocate(CS%layers(i)%A)
+    deallocate(CS%layers(i)%b)
+  enddo
+  deallocate(CS%layers)
+
+end subroutine ANN_end
+
+!> Main ANN function: normalizes input vector x, applies Linear layers, and 
+!! un-normalizes the output.
+subroutine ANN_apply(x, y, CS)
+  type(ANN_CS), intent(in) :: CS !< ANN control structure
+
+  real, dimension(CS%layer_sizes(1)), &
+                  intent(in)  :: x !< input 
+  real, dimension(CS%layer_sizes(CS%num_layers)), &
+                  intent(out) :: y !< output 
+  
+  real, allocatable :: x_1(:), x_2(:) ! intermediate states. 
+  integer :: i
+
+  ! Normalize input
+  allocate(x_1(CS%layer_sizes(1)))
+  do i = 1,CS%layer_sizes(1)
+      x_1(i) = x(i) / CS%input_norms(i)
+  enddo
+  
+  ! Apply Linear layers
+  do i = 1, CS%num_layers-1 
+    allocate(x_2(CS%layer_sizes(i+1)))
+    call Layer_apply(x_1, x_2, CS%layers(i))
+    deallocate(x_1)
+    allocate(x_1(CS%layer_sizes(i+1)))
+    x_1 = x_2
+    deallocate(x_2)
+  enddo
+  
+  ! Un-normalize output
+  do i = 1, CS%layer_sizes(CS%num_layers)
+    y(i) = x_1(i) * CS%output_norms(i)
+  enddo
+
+  deallocate(x_1)
+end subroutine ANN_apply
+
+!> The default activation function
+pure function activation_fn(x) result (y)
+  real, intent(in)  :: x !< Scalar input value
+  real :: y !< Scalar output value
+
+  y = max(x, 0.0) ! ReLU activation
+  
+end function activation_fn
+
+!> Applies linear layer to input data x and stores the result in y with 
+!! y = A*x + b with optional application of the activation function.
+subroutine Layer_apply(x, y, layer)
+  type(layer_type), intent(in)  :: layer !< Linear layer
+  real, dimension(layer%input_width), &
+                    intent(in)  :: x     !< Input vector
+  real, dimension(layer%output_width), &
+                    intent(out) :: y     !< Output vector
+
+  integer :: i, j
+
+  do j=1,layer%output_width
+    y(j) = 0.
+    do i=1,layer%input_width
+      ! Multiply by kernel
+      y(j) = y(j) + ( x(i) * layer%A(j, i) )
+    enddo
+    ! Add bias
+    y(j) = y(j) + layer%b(j)
+    ! Apply activation function
+    if (layer%activation) then
+      y(j) = activation_fn(y(j))
+    endif
+  enddo
+end subroutine Layer_apply
+
+end module MOM_ANN

--- a/src/parameterizations/lateral/MOM_Zanna_Bolton.F90
+++ b/src/parameterizations/lateral/MOM_Zanna_Bolton.F90
@@ -15,12 +15,15 @@ use MOM_domains,       only : To_North, To_East
 use MOM_domains,       only : pass_var, CORNER
 use MOM_cpu_clock,     only : cpu_clock_id, cpu_clock_begin, cpu_clock_end
 use MOM_cpu_clock,     only : CLOCK_MODULE, CLOCK_ROUTINE
+use MOM_ANN,           only : ANN_init, ANN_apply, ANN_end, ANN_CS
 
 implicit none ; private
 
 #include <MOM_memory.h>
 
 public ZB2020_lateral_stress, ZB2020_init, ZB2020_end, ZB2020_copy_gradient_and_thickness
+
+logical, public :: true_vorticity !< Use correct curvilinear coordinate expression for vorticity
 
 !> Control structure for Zanna-Bolton-2020 parameterization.
 type, public :: ZB2020_CS ; private
@@ -76,6 +79,12 @@ type, public :: ZB2020_CS ; private
         maskw_h,  & !< Mask of land point at h points multiplied by filter weight [nondim]
         maskw_q     !< Same mask but for q points [nondim]
 
+  integer :: use_ann  !< 0: ANN is turned off, 3: ANN is used
+  integer :: stencil_size  !< Default is 3x3
+  type(ANN_CS) :: ann_Tall !< ANN instance for off-diagonal and diagonal stress
+  character(len=200) :: ann_file_Tall
+  real :: subroundoff_shear
+
   type(diag_ctrl), pointer :: diag => NULL() !< A type that regulates diagnostics output
   !>@{ Diagnostic handles
   integer :: id_ZB2020u = -1, id_ZB2020v = -1, id_KE_ZB2020 = -1
@@ -90,6 +99,7 @@ type, public :: ZB2020_CS ; private
   integer :: id_clock_copy
   integer :: id_clock_cdiss
   integer :: id_clock_stress
+  integer :: id_clock_stress_ANN
   integer :: id_clock_divergence
   integer :: id_clock_mpi
   integer :: id_clock_filter
@@ -141,9 +151,23 @@ subroutine ZB2020_init(Time, G, GV, US, param_file, diag, CS, use_ZB2020)
                  "subgrid momentum parameterization of mesoscale eddies.", default=.false.)
   if (.not. use_ZB2020) return
 
+  call get_param(param_file, mdl, "USE_ANN", CS%use_ann, &
+                 "ANN inference of momentum fluxes: 0 off, 3: use ANN", default=0)
+
+  call get_param(param_file, mdl, "ANN_STENCIL_SIZE", CS%stencil_size, &
+                 "ANN stencil size", default=3)
+
+  call get_param(param_file, mdl, "ANN_TRUE_VORTICITY", true_vorticity, &
+                 "Use correct curvilinear approximation of vorticity", &
+                 default=.False.)
+
+  call get_param(param_file, mdl, "ANN_FILE_TALL", CS%ann_file_Tall, &
+                 "ANN parameters for prediction of Txy, Txx and Tyy netcdf input", &
+                 default="INPUT/EXP1/Tall.nc")
+
   call get_param(param_file, mdl, "ZB_SCALING", CS%amplitude, &
                  "The nondimensional scaling factor in ZB model, " //&
-                 "typically 0.5-2.5", units="nondim", default=0.5)
+                 "typically 0.5-2.5", units="nondim", default=1.0)
 
   call get_param(param_file, mdl, "ZB_TRACE_MODE", CS%ZB_type, &
                  "Select how to compute the trace part of ZB model:\n" //&
@@ -214,11 +238,17 @@ subroutine ZB2020_init(Time, G, GV, US, param_file, diag, CS, use_ZB2020)
   CS%id_clock_copy = cpu_clock_id('(ZB2020 copy fields)', grain=CLOCK_ROUTINE, sync=.false.)
   CS%id_clock_cdiss = cpu_clock_id('(ZB2020 compute c_diss)', grain=CLOCK_ROUTINE, sync=.false.)
   CS%id_clock_stress = cpu_clock_id('(ZB2020 compute stress)', grain=CLOCK_ROUTINE, sync=.false.)
+  CS%id_clock_stress_ANN = cpu_clock_id('(ZB2020 compute stress ANN)', grain=CLOCK_ROUTINE, sync=.false.)
   CS%id_clock_divergence = cpu_clock_id('(ZB2020 compute divergence)', grain=CLOCK_ROUTINE, sync=.false.)
   CS%id_clock_mpi = cpu_clock_id('(ZB2020 filter MPI exchanges)', grain=CLOCK_ROUTINE, sync=.false.)
   CS%id_clock_filter = cpu_clock_id('(ZB2020 filter no MPI)', grain=CLOCK_ROUTINE, sync=.false.)
   CS%id_clock_post = cpu_clock_id('(ZB2020 post data)', grain=CLOCK_ROUTINE, sync=.false.)
   CS%id_clock_source = cpu_clock_id('(ZB2020 compute energy source)', grain=CLOCK_ROUTINE, sync=.false.)
+
+  CS%subroundoff_shear = 1e-30 * US%T_to_s
+  if (CS%use_ann == 3) then
+    call ANN_init(CS%ann_Tall, CS%ann_file_Tall)
+  endif
 
   ! Allocate memory
   ! We set the stress tensor and velocity gradient tensor to zero
@@ -237,11 +267,11 @@ subroutine ZB2020_init(Time, G, GV, US, param_file, diag, CS, use_ZB2020)
 
   ! Precomputing the scaling coefficient
   ! Mask is included to automatically satisfy B.C.
-  do j=js-1,je+1 ; do i=is-1,ie+1
+  do j=js-2,je+2 ; do i=is-2,ie+2
     CS%kappa_h(i,j) = -CS%amplitude * G%areaT(i,j) * G%mask2dT(i,j)
   enddo; enddo
 
-  do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+  do J=Jsq-2,Jeq+2 ; do I=Isq-2,Ieq+2
     CS%kappa_q(I,J) = -CS%amplitude * G%areaBu(I,J) * G%mask2dBu(I,J)
   enddo; enddo
 
@@ -316,6 +346,10 @@ subroutine ZB2020_end(CS)
   if (CS%Stress_iter > 0 .or. CS%HPF_iter > 0) then
     deallocate(CS%maskw_h)
     deallocate(CS%maskw_q)
+  endif
+
+  if (CS%use_ann == 3) then
+    call ANN_end(CS%ann_Tall)
   endif
 
 end subroutine ZB2020_end
@@ -432,7 +466,12 @@ subroutine ZB2020_lateral_stress(u, v, h, diffu, diffv, G, GV, CS, &
 
   ! Compute the stress tensor given the
   ! (optionally sharpened) velocity gradients
-  call compute_stress(G, GV, CS)
+  if (CS%use_ann==0) then
+    call compute_stress(G, GV, CS)
+  elseif (CS%use_ann==3) then
+    call compute_stress_ANN_collocated(G, GV, CS)
+  endif
+
 
   ! Smooth the stress tensor if specified
   call filter_stress(G, GV, CS)
@@ -613,6 +652,123 @@ subroutine compute_stress(G, GV, CS)
 
 end subroutine compute_stress
 
+!> Compute stress tensor T =
+!! (Txx, Txy;
+!!  Txy, Tyy)
+!! with ANN in non-dimensional form:
+!! T = dx^2 * |grad V|^2 * ANN(grad V / |grad V|)
+!! The sign of the stress tensor is such that:
+!! (du/dt, dv/dt) = 1/h * div(h * T)
+!! Algorithm:
+!! 1) Interpolate input features (sh_xy, sh_xx, vort_xy) to grid centers
+!! 2) Compute norm of velocity gradients on a stencil
+!! 3) Non-dimensionalize input features
+!! 4) Make ANN inference in grid centers
+!! 5) Restore physical dimensionality and interpolate Txy back to corners
+subroutine compute_stress_ANN_collocated(G, GV, CS)
+  type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure.
+  type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
+  type(ZB2020_CS),         intent(inout) :: CS   !< ZB2020 control structure.
+
+  integer :: is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
+  integer :: i, j, k, n
+
+  real :: x(3*CS%stencil_size**2)    ! Vector of non-dimensional input features
+                                     ! (sh_xy, sh_xx, vort_xy) on a stencil    [nondim]
+  real :: y(3)                       ! Vector of nondimensional
+                                     ! output features (Txy,Txx,Tyy) [nondim]
+  real :: input_norm                 ! Norm of input features [T-1 ~ s-1]
+  integer :: offset                  ! Half the stencil size. Used for selection
+  integer :: stencil_points          ! The number of points after flattening
+
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: &
+        sh_xy_h,   & ! sh_xy interpolated to the center [T-1 ~ s-1]
+        vort_xy_h, & ! vort_xy interpolated to the center [T-1 ~ s-1]
+        norm_h       ! Norm of input feautres in center points [T-1 ~ s-1]
+
+  real, dimension(SZI_(G),SZJ_(G)) :: &
+        sqr_h, & ! Squared norm of velocity gradients in center points [T-2 ~ s-2]
+        Txy      ! Predicted Txy in center points                      [T-1 ~ s-1]
+
+  call cpu_clock_begin(CS%id_clock_stress_ANN)
+
+  is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
+  Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
+
+  sh_xy_h = 0.
+  vort_xy_h = 0.
+  norm_h = 0.
+
+  call pass_var(CS%sh_xy, G%Domain, clock=CS%id_clock_mpi, position=CORNER)
+  call pass_var(CS%sh_xx, G%Domain, clock=CS%id_clock_mpi)
+  call pass_var(CS%vort_xy, G%Domain, clock=CS%id_clock_mpi, position=CORNER)
+
+  offset = (CS%stencil_size-1)/2
+  stencil_points = CS%stencil_size**2
+
+  ! Interpolate input features
+  do k=1,nz
+    do j=js-2,je+2 ; do i=is-2,ie+2
+      ! It is assumed that B.C. is applied to sh_xy and vort_xy
+      sh_xy_h(i,j,k) = 0.25 * ( (CS%sh_xy(I-1,J-1,k) + CS%sh_xy(I,J,k)) &
+                              + (CS%sh_xy(I-1,J,k) + CS%sh_xy(I,J-1,k)) )
+
+      vort_xy_h(i,j,k) = 0.25 * ( (CS%vort_xy(I-1,J-1,k) + CS%vort_xy(I,J,k)) &
+                                + (CS%vort_xy(I-1,J,k) + CS%vort_xy(I,J-1,k)) )
+      
+      sqr_h(i,j) = (CS%sh_xx(i,j,k)**2 + sh_xy_h(i,j,k)**2 + vort_xy_h(i,j,k)**2) * G%mask2dT(i,j)
+    enddo; enddo
+
+    do j=js,je ; do i=is,ie
+      norm_h(i,j,k) = sqrt(SUM(sqr_h(i-offset:i+offset, &
+                                     j-offset:j+offset)))
+    enddo; enddo
+  enddo
+
+  call pass_var(sh_xy_h, G%Domain, clock=CS%id_clock_mpi)
+  call pass_var(vort_xy_h, G%Domain, clock=CS%id_clock_mpi)
+  call pass_var(norm_h, G%Domain, clock=CS%id_clock_mpi) 
+
+  do k=1,nz
+    do j=js-2,je+2 ; do i=is-2,ie+2
+      x(1:stencil_points) =                                                            &
+                        RESHAPE(sh_xy_h(i-offset:i+offset,                             &
+                                        j-offset:j+offset,k), (/stencil_points/))
+      x(stencil_points+1:2*stencil_points) =                                           &
+                        RESHAPE(CS%sh_xx(i-offset:i+offset,                            &
+                                         j-offset:j+offset,k), (/stencil_points/))
+      x(2*stencil_points+1:3*stencil_points) =                                         &
+                        RESHAPE(vort_xy_h(i-offset:i+offset,                           &
+                                          j-offset:j+offset,k), (/stencil_points/))
+
+      input_norm = norm_h(i,j,k)
+
+      x(:) = x(:) / (input_norm + CS%subroundoff_shear)
+
+      call ANN_apply(x, y, CS%ann_Tall)
+
+      y = y * input_norm * input_norm * CS%kappa_h(i,j)
+
+      Txy(i,j)      = y(1)
+      CS%Txx(i,j,k) = y(2)
+      CS%Tyy(i,j,k) = y(3)
+    enddo ; enddo
+
+    do J=Jsq-1,Jeq+1 ; do I=Isq-1,Ieq+1
+      CS%Txy(I,J,k) = 0.25 * ( (Txy(i+1,j+1) + Txy(i,j)) &
+                             + (Txy(i+1,j)   + Txy(i,j+1))) * G%mask2dBu(I,J)
+    enddo; enddo
+
+  enddo ! end of k loop
+
+  call pass_var(CS%Txy, G%Domain, clock=CS%id_clock_mpi, position=CORNER)
+  call pass_var(CS%Txx, G%Domain, clock=CS%id_clock_mpi)
+  call pass_var(CS%Tyy, G%Domain, clock=CS%id_clock_mpi)
+
+  call cpu_clock_end(CS%id_clock_stress_ANN)
+
+end subroutine compute_stress_ANN_collocated
+
 !> Compute the divergence of subgrid stress
 !! weighted with thickness, i.e.
 !! (fx,fy) = 1/h Div(h * [Txx, Txy; Txy, Tyy])
@@ -712,24 +868,22 @@ subroutine compute_stress_divergence(u, v, h, diffu, diffv, dx2h, dy2h, dx2q, dy
       enddo ; enddo
     endif
 
-    ! Evaluate 1/h x.Div(h S) (Line 1495 of MOM_hor_visc.F90)
-    ! Minus occurs because in original file (du/dt) = - div(S),
-    ! but here is the discretization of div(S)
+    ! Evaluate du/dt=1/h x.Div(h T) (Line 1495 of MOM_hor_visc.F90)
     do j=js,je ; do I=Isq,Ieq
       h_u = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i+1,j)*h(i+1,j,k)) + h_neglect
-      fx = -((G%IdyCu(I,j)*(Mxx(i,j) - Mxx(i+1,j)) + &
-              G%IdxCu(I,j)*(dx2q(I,J-1)*Mxy(I,J-1) - dx2q(I,J)*Mxy(I,J))) * &
+      fx =  ((G%IdyCu(I,j)*(Mxx(i+1,j) - Mxx(i,j)) + &
+              G%IdxCu(I,j)*(dx2q(I,J)*Mxy(I,J) - dx2q(I,J-1)*Mxy(I,J-1))) * &
               G%IareaCu(I,j)) / h_u
       diffu(I,j,k) = diffu(I,j,k) + fx
       if (save_ZB2020u) &
         ZB2020u(I,j,k) = fx
     enddo ; enddo
 
-    ! Evaluate 1/h y.Div(h S) (Line 1517 of MOM_hor_visc.F90)
+    ! Evaluate dv/dt=1/h y.Div(h T) (Line 1517 of MOM_hor_visc.F90)
     do J=Jsq,Jeq ; do i=is,ie
       h_v = 0.5 * (G%mask2dT(i,j)*h(i,j,k) + G%mask2dT(i,j+1)*h(i,j+1,k)) + h_neglect
-      fy = -((G%IdxCv(i,J)*(Myy(i,j) - Myy(i,j+1)) + &
-              G%IdyCv(i,J)*(dy2q(I-1,J)*Mxy(I-1,J) - dy2q(I,J)*Mxy(I,J))) * &
+      fy =  ((G%IdxCv(i,J)*(Myy(i,j+1) - Myy(i,j)) + &
+              G%IdyCv(i,J)*(dy2q(I,J)*Mxy(I,J) - dy2q(I-1,J)*Mxy(I-1,J))) * &
               G%IareaCv(i,J)) / h_v
       diffv(i,J,k) = diffv(i,J,k) + fy
       if (save_ZB2020v) &
@@ -1076,7 +1230,7 @@ subroutine compute_energy_source(u, v, h, fx, fy, G, GV, CS)
           G%dxCv(i,J)
         KE_v(i,J) = vh * G%dyCv(i,J) * fy(i,J,k)
       enddo ; enddo
-      call do_group_pass(pass_KE_uv, G%domain)
+      call do_group_pass(pass_KE_uv, G%domain, clock=CS%id_clock_mpi)
       do j=js,je ; do i=is,ie
         KE_term(i,j,k) = 0.5 * G%IareaT(i,j) &
             * ((KE_u(I,j) + KE_u(I-1,j)) + (KE_v(i,J) + KE_v(i,J-1)))

--- a/src/parameterizations/lateral/MOM_Zanna_Bolton.F90
+++ b/src/parameterizations/lateral/MOM_Zanna_Bolton.F90
@@ -715,7 +715,7 @@ subroutine compute_stress_ANN_collocated(G, GV, CS)
 
       vort_xy_h(i,j,k) = 0.25 * ( (CS%vort_xy(I-1,J-1,k) + CS%vort_xy(I,J,k)) &
                                 + (CS%vort_xy(I-1,J,k) + CS%vort_xy(I,J-1,k)) )
-   
+
       sqr_h(i,j) = (CS%sh_xx(i,j,k)**2 + sh_xy_h(i,j,k)**2 + vort_xy_h(i,j,k)**2) * G%mask2dT(i,j)
     enddo; enddo
 

--- a/src/parameterizations/lateral/MOM_Zanna_Bolton.F90
+++ b/src/parameterizations/lateral/MOM_Zanna_Bolton.F90
@@ -82,8 +82,8 @@ type, public :: ZB2020_CS ; private
   integer :: use_ann  !< 0: ANN is turned off, 3: ANN is used
   integer :: stencil_size  !< Default is 3x3
   type(ANN_CS) :: ann_Tall !< ANN instance for off-diagonal and diagonal stress
-  character(len=200) :: ann_file_Tall
-  real :: subroundoff_shear
+  character(len=200) :: ann_file_Tall !< Path to netcdf file with ANN
+  real :: subroundoff_shear !< Small dimensional constant for save division by zero [T-1 ~ s-1]
 
   type(diag_ctrl), pointer :: diag => NULL() !< A type that regulates diagnostics output
   !>@{ Diagnostic handles
@@ -715,7 +715,7 @@ subroutine compute_stress_ANN_collocated(G, GV, CS)
 
       vort_xy_h(i,j,k) = 0.25 * ( (CS%vort_xy(I-1,J-1,k) + CS%vort_xy(I,J,k)) &
                                 + (CS%vort_xy(I-1,J,k) + CS%vort_xy(I,J-1,k)) )
-      
+   
       sqr_h(i,j) = (CS%sh_xx(i,j,k)**2 + sh_xy_h(i,j,k)**2 + vort_xy_h(i,j,k)**2) * G%mask2dT(i,j)
     enddo; enddo
 
@@ -727,7 +727,7 @@ subroutine compute_stress_ANN_collocated(G, GV, CS)
 
   call pass_var(sh_xy_h, G%Domain, clock=CS%id_clock_mpi)
   call pass_var(vort_xy_h, G%Domain, clock=CS%id_clock_mpi)
-  call pass_var(norm_h, G%Domain, clock=CS%id_clock_mpi) 
+  call pass_var(norm_h, G%Domain, clock=CS%id_clock_mpi)
 
   do k=1,nz
     do j=js-2,je+2 ; do i=is-2,ie+2

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -671,7 +671,8 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$OMP   h_neglect, h_neglect3, inv_PI3, inv_PI6, &
   !$OMP   diffu, diffv, Kh_h, Kh_q, Ah_h, Ah_q, FrictWork, FrictWork_bh, FrictWork_GME, &
   !$OMP   div_xx_h, sh_xx_h, vort_xy_q, sh_xy_q, GME_coeff_h, GME_coeff_q, &
-  !$OMP   KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah, NoSt, ShSt, hu_cont, hv_cont &
+  !$OMP   KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah, NoSt, ShSt, hu_cont, hv_cont, &
+  !$OMP   true_vorticity &
   !$OMP ) &
   !$OMP private( &
   !$OMP   i, j, k, n, tmp, &

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -25,7 +25,7 @@ use MOM_unit_scaling,          only : unit_scale_type
 use MOM_verticalGrid,          only : verticalGrid_type
 use MOM_variables,             only : accel_diag_ptrs, thermo_var_ptrs
 use MOM_Zanna_Bolton,          only : ZB2020_lateral_stress, ZB2020_init, ZB2020_end
-use MOM_Zanna_Bolton,          only : ZB2020_CS, ZB2020_copy_gradient_and_thickness, true_vorticity
+use MOM_Zanna_Bolton,          only : ZB2020_CS, ZB2020_copy_gradient_and_thickness
 
 implicit none ; private
 
@@ -132,6 +132,7 @@ type, public :: hor_visc_CS ; private
   logical :: use_cont_thick_bug  !< If true, retain an answer-changing bug for thickness at velocity points.
   type(ZB2020_CS) :: ZB2020  !< Zanna-Bolton 2020 control structure.
   logical :: use_ZB2020      !< If true, use Zanna-Bolton 2020 parameterization.
+  logical :: use_circulation !< If true, use circulation theorem to compute vorticity (for ZB20 or Leith)
 
   real ALLOCABLE_, dimension(NIMEM_,NJMEM_) :: Kh_bg_xx
                       !< The background Laplacian viscosity at h points [L2 T-1 ~> m2 s-1].
@@ -671,8 +672,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
   !$OMP   h_neglect, h_neglect3, inv_PI3, inv_PI6, &
   !$OMP   diffu, diffv, Kh_h, Kh_q, Ah_h, Ah_q, FrictWork, FrictWork_bh, FrictWork_GME, &
   !$OMP   div_xx_h, sh_xx_h, vort_xy_q, sh_xy_q, GME_coeff_h, GME_coeff_q, &
-  !$OMP   KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah, NoSt, ShSt, hu_cont, hv_cont, &
-  !$OMP   true_vorticity &
+  !$OMP   KH_u_GME, KH_v_GME, grid_Re_Kh, grid_Re_Ah, NoSt, ShSt, hu_cont, hv_cont &
   !$OMP ) &
   !$OMP private( &
   !$OMP   i, j, k, n, tmp, &
@@ -959,7 +959,7 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           vort_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) - dudy(I,J) )
         enddo ; enddo
       else
-        if (true_vorticity) then
+        if (CS%use_circulation) then
           do J=js_vort,je_vort ; do I=is_vort,ie_vort
             vort_xy(I,J) = G%mask2dBu(I,J) * G%IareaBu(I,J) * (  &
               (v(i+1,J,k)*G%dyCv(i+1,J) - v(i,J,k)*G%dyCv(i,J))  &
@@ -2368,6 +2368,10 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   CS%diag => diag
   ! Read parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
+
+  call get_param(param_file, mdl, "USE_CIRCULATION_IN_STRAIN", CS%use_circulation, &
+                 "Use circulation theorem to compute vorticity (for ZB20 or Leith)", &
+                 default=.False.)
 
   ! All parameters are read in all cases to enable parameter spelling checks.
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -25,7 +25,7 @@ use MOM_unit_scaling,          only : unit_scale_type
 use MOM_verticalGrid,          only : verticalGrid_type
 use MOM_variables,             only : accel_diag_ptrs, thermo_var_ptrs
 use MOM_Zanna_Bolton,          only : ZB2020_lateral_stress, ZB2020_init, ZB2020_end
-use MOM_Zanna_Bolton,          only : ZB2020_CS, ZB2020_copy_gradient_and_thickness
+use MOM_Zanna_Bolton,          only : ZB2020_CS, ZB2020_copy_gradient_and_thickness, true_vorticity
 
 implicit none ; private
 
@@ -958,9 +958,18 @@ subroutine horizontal_viscosity(u, v, h, uh, vh, diffu, diffv, MEKE, VarMix, G, 
           vort_xy(I,J) = (2.0-G%mask2dBu(I,J)) * ( dvdx(I,J) - dudy(I,J) )
         enddo ; enddo
       else
-        do J=js_vort,je_vort ; do I=is_vort,ie_vort
-          vort_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) - dudy(I,J) )
-        enddo ; enddo
+        if (true_vorticity) then
+          do J=js_vort,je_vort ; do I=is_vort,ie_vort
+            vort_xy(I,J) = G%mask2dBu(I,J) * G%IareaBu(I,J) * (  &
+              (v(i+1,J,k)*G%dyCv(i+1,J) - v(i,J,k)*G%dyCv(i,J))  &
+            - (u(I,j+1,k)*G%dxCu(I,j+1) - u(I,j,k)*G%dxCu(I,j))  &
+             )
+          enddo ; enddo
+        else
+          do J=js_vort,je_vort ; do I=is_vort,ie_vort
+            vort_xy(I,J) = G%mask2dBu(I,J) * ( dvdx(I,J) - dudy(I,J) )
+          enddo ; enddo
+        endif
       endif
     endif
 

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2369,8 +2369,8 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   ! Read parameters and write them to the model log.
   call log_version(param_file, mdl, version, "")
 
-  call get_param(param_file, mdl, "USE_CIRCULATION_IN_STRAIN", CS%use_circulation, &
-                 "Use circulation theorem to compute vorticity (for ZB20 or Leith)", &
+  call get_param(param_file, mdl, "USE_CIRCULATION_IN_HORVISC", CS%use_circulation, &
+                 "Use circulation theorem to compute vorticity in horvisc module (for ZB20 or Leith)", &
                  default=.False.)
 
   ! All parameters are read in all cases to enable parameter spelling checks.


### PR DESCRIPTION
This PR implements ANN parameterization of mesoscale eddies. Changes to the main branch include:
* Module for ANN inference `MOM_ANN.F90`
* Computing subgrid stress using ANN in `MOM_Zanna_Bolton.F90`

Default MOM_override for ANN usage:
```
#override USE_ZB2020 = True
#override USE_ANN = 3
#override ANN_STENCIL_SIZE = 3
#override ANN_TRUE_VORTICITY = True
#override ANN_FILE_TALL = /path/to/ocean3d/subfilter/FGR3/EXP1/model/Tall.nc
```

The netcdf files with ANN weights are attached [ANN-weights.zip](https://github.com/user-attachments/files/19897829/ANN-weights.zip)